### PR TITLE
Fix  #8 docker.sock error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,5 +5,6 @@ zabbix-agent-xxl:
     - "10050:10050"
   volumes:
     - /:/rootfs
+    - /var/run:/var/run
   environment:
     - ZA_Server=<ZABBIX SERVER IP/DNS NAME>


### PR DESCRIPTION
When use `docker-compose up` then docker host will not be able to stop the container. It suppose to have /var/run volume.

```
root@:/zabbix-agent# docker-compose up
Attaching to zabbixagent_zabbix-agent-xxl_1
zabbix-agent-xxl_1  | Zocker XXL v0.9.3b public limited version
zabbix-agent-xxl_1  | Copyright (C) 2014-2016 Jan Garaj - www.monitoringartist.com 
zabbix-agent-xxl_1  | Freeware licence - Usage of this binary is restricted to oficial monitoringartist Docker ima
ges only.
  1 zabbix-agent-xxl:
zabbix-agent-xxl_1  | Starting Zabbix Agent [baas-db1]. Zabbix 3.0.2 XXL (2016-05-09) (revision {ZABBIX_REVISION})
.
zabbix-agent-xxl_1  | Press Ctrl+C to exit.
zabbix-agent-xxl_1  | 
zabbix-agent-xxl_1  |      9:20160531:002538.813 Starting Zabbix Agent [baas-db1]. Zabbix 3.0.2 XXL (2016-05-09) (
revision {ZABBIX_REVISION}).
zabbix-agent-xxl_1  |      9:20160531:002538.813 **** Enabled features ****
zabbix-agent-xxl_1  |      9:20160531:002538.813 IPv6 support:          YES
zabbix-agent-xxl_1  |      9:20160531:002538.813 TLS support:           YES
zabbix-agent-xxl_1  |      9:20160531:002538.813 **************************
zabbix-agent-xxl_1  |      9:20160531:002538.813 using configuration file: /etc/zabbix/zabbix_agentd.conf
zabbix-agent-xxl_1  |      9:20160531:002538.813 Cannot connect to standard docker's socket /var/run/docker.sock
zabbix-agent-xxl_1  | *** Error in `/usr/local/sbin/zabbix_agentd': munmap_chunk(): invalid pointer: 0x00007f4f325
e7e80 ***
```

```
root@:/zabbix-agent# docker-compose down
Stopping zabbix-agent-xxl_1 ... 

ERROR: for zabbix-agent-xxl_1  UnixHTTPConnectionPool(host='localhost', port=None): Read timed out. (read timeout=70)
ERROR: An HTTP request took too long to complete. Retry with --verbose to obtain debug information.
If you encounter this issue regularly because of slow network conditions, consider setting COMPOSE_HTTP_TIMEOUT to a higher value (current value: 60).
```
